### PR TITLE
Filter integration tests as it takes too long to compile

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,7 +36,7 @@ jobs:
         # issue: pattern ./...: directory prefix . does not contain main module or its selected dependencies
         # see https://github.com/golangci/golangci-lint/issues/2654
         # or, maybe, just maybe, I simply forgot to add actions/checkout like a dummy
-        run: go test -v ./... # -coverprofile=coverage.txt -covermode=atomic
+        run: go test -v ./pkg/... ./docs/... # -coverprofile=coverage.txt -covermode=atomic
       - name: golangci-lint
         uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5 # v3.4.0
         with:

--- a/docs/terraform/aws_test.go
+++ b/docs/terraform/aws_test.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2023 Volvo Car Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build inttest
+
 package terraform
 
 import (

--- a/docs/terraform/example_backend_test.go
+++ b/docs/terraform/example_backend_test.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2023 Volvo Car Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build inttest
+
 package terraform_test
 
 import (

--- a/docs/terraform/example_minimal_stack_test.go
+++ b/docs/terraform/example_minimal_stack_test.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2023 Volvo Car Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build inttest
+
 package terraform_test
 
 import (

--- a/docs/terraform/generate.go
+++ b/docs/terraform/generate.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2023 Volvo Car Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build inttest
+
 package terraform
 
 //go:generate echo ">>>> generating terraform readme\n"

--- a/docs/terraform/types_test.go
+++ b/docs/terraform/types_test.go
@@ -1,6 +1,8 @@
 // Copyright (c) 2023 Volvo Car Corporation
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build inttest
+
 package terraform
 
 import (


### PR DESCRIPTION
Now the tests take seconds instead of timing out at 37 min 😄 