### PR TITLE
chore: implement internal version of hcl.Traversal

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -12,6 +12,7 @@ project {
     ".vscode/**",
     "bin/**",
     "**/.lingon/**",
+    "**/.terra/**",
     "**/testdata/**",
     "**/out/**",
      "vendors/**",

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 # Local .lingon directories (generated code)
 **/.lingon/*
-**/.terriyaki/*
+**/.terra/*
 
 # Terraform state files
 *.tfstate

--- a/NOTICE
+++ b/NOTICE
@@ -15,7 +15,7 @@ github.com/gogo/protobuf v1.3.2 : BSD-3-Clause
 github.com/google/go-cmp/cmp v0.5.9 : BSD-3-Clause
 github.com/google/gofuzz v1.2.0 : Apache-2.0
 github.com/hashicorp/go-version v1.6.0 : MPL-2.0
-github.com/hashicorp/hcl/v2 v2.16.0-patch-1 : MPL-2.0
+github.com/hashicorp/hcl/v2 v2.16.2 : MPL-2.0
 github.com/hashicorp/terraform-exec v0.18.1 : MPL-2.0
 github.com/hashicorp/terraform-json v0.16.0 : MPL-2.0
 github.com/imdario/mergo v0.3.15 : BSD-3-Clause
@@ -78,7 +78,7 @@ github.com/google/gofuzz v1.2.0
 
 github.com/hashicorp/go-version v1.6.0
 
-github.com/hashicorp/hcl/v2 v2.16.0-patch-1
+github.com/hashicorp/hcl/v2 v2.16.2
 
 github.com/hashicorp/terraform-exec v0.18.1
 
@@ -1450,7 +1450,7 @@ Exhibit B - “Incompatible With Secondary Licenses” Notice
 ---
 
 MPL-2.0
-(github.com/hashicorp/hcl/v2 v2.16.0-patch-1)
+(github.com/hashicorp/hcl/v2 v2.16.2)
 
 Copyright (c) 2014 HashiCorp, Inc.
 

--- a/example/go.mod
+++ b/example/go.mod
@@ -4,8 +4,6 @@ go 1.20
 
 replace github.com/volvo-cars/lingon => ../
 
-replace github.com/hashicorp/hcl/v2 => github.com/jlarfors/hcl/v2 v2.16.0-patch-1
-
 require (
 	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/aws/karpenter v0.27.1

--- a/example/go.sum
+++ b/example/go.sum
@@ -70,6 +70,8 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hc-install v0.5.0 h1:D9bl4KayIYKEeJ4vUDe9L5huqxZXczKaykSRcmQ0xY0=
+github.com/hashicorp/hcl/v2 v2.16.2 h1:mpkHZh/Tv+xet3sy3F9Ld4FyI2tUpWe9x3XtPx9f1a0=
+github.com/hashicorp/hcl/v2 v2.16.2/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
 github.com/hashicorp/terraform-exec v0.18.1 h1:LAbfDvNQU1l0NOQlTuudjczVhHj061fNX5H8XZxHlH4=
 github.com/hashicorp/terraform-exec v0.18.1/go.mod h1:58wg4IeuAJ6LVsLUeD2DWZZoc/bYi6dzhLHzxM41980=
 github.com/hashicorp/terraform-json v0.16.0 h1:UKkeWRWb23do5LNAFlh/K3N0ymn1qTOO8c+85Albo3s=
@@ -84,8 +86,6 @@ github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/invopop/yaml v0.2.0 h1:7zky/qH+O0DwAyoobXUqvVBwgBFRxKoQ/3FjcVpjTMY=
 github.com/invopop/yaml v0.2.0/go.mod h1:2XuRLgs/ouIrW3XNzuNj7J3Nvu/Dig5MXvbCEdiBN3Q=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
-github.com/jlarfors/hcl/v2 v2.16.0-patch-1 h1:IhyzCFZets9vKPfs8cFfLTSCkR2NNDT/mbqPwR/lGtI=
-github.com/jlarfors/hcl/v2 v2.16.0-patch-1/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,6 @@ go 1.20
 
 replace github.com/dave/jennifer => github.com/veggiemonk/jennifer v0.0.0-20230131124350-60c16b6e1cb9
 
-replace github.com/hashicorp/hcl/v2 => github.com/jlarfors/hcl/v2 v2.16.0-patch-1
-
 require (
 	github.com/dave/jennifer v1.6.0
 	github.com/go-playground/validator/v10 v10.12.0

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
 github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hc-install v0.5.0 h1:D9bl4KayIYKEeJ4vUDe9L5huqxZXczKaykSRcmQ0xY0=
+github.com/hashicorp/hcl/v2 v2.16.2 h1:mpkHZh/Tv+xet3sy3F9Ld4FyI2tUpWe9x3XtPx9f1a0=
+github.com/hashicorp/hcl/v2 v2.16.2/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
 github.com/hashicorp/terraform-exec v0.18.1 h1:LAbfDvNQU1l0NOQlTuudjczVhHj061fNX5H8XZxHlH4=
 github.com/hashicorp/terraform-exec v0.18.1/go.mod h1:58wg4IeuAJ6LVsLUeD2DWZZoc/bYi6dzhLHzxM41980=
 github.com/hashicorp/terraform-json v0.16.0 h1:UKkeWRWb23do5LNAFlh/K3N0ymn1qTOO8c+85Albo3s=
@@ -44,8 +46,6 @@ github.com/hashicorp/terraform-json v0.16.0/go.mod h1:v0Ufk9jJnk6tcIZvScHvetlKfi
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=
 github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
-github.com/jlarfors/hcl/v2 v2.16.0-patch-1 h1:IhyzCFZets9vKPfs8cFfLTSCkR2NNDT/mbqPwR/lGtI=
-github.com/jlarfors/hcl/v2 v2.16.0-patch-1/go.mod h1:JRmR89jycNkrrqnMmvPDMd56n1rQJ2Q6KocSLCMCXng=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/pkg/terra/reference.go
+++ b/pkg/terra/reference.go
@@ -4,7 +4,9 @@
 package terra
 
 import (
-	"github.com/hashicorp/hcl/v2"
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	tkihcl "github.com/volvo-cars/lingon/pkg/internal/hcl"
 	"github.com/zclconf/go-cty/cty"
@@ -77,76 +79,223 @@ var _ tkihcl.Tokenizer = (*Reference)(nil)
 
 // Reference represents a reference to some value in a Terraform configuration.
 // The reference might include things like indices (i.e. [0]),
-// nested objects or even the splat operator (i.e. [*])
+// nested objects or even the splat operator (i.e. [*]).
+//
+// A reference can be created by passing a [Resource] to
+// [ReferenceResource] or passing a [DataResource] to
+// [ReferenceDataResource].
 type Reference struct {
 	underlyingType referenceUnderlyingType
 	res            Resource
 	data           DataResource
-	tr             hcl.Traversal
+
+	steps []referenceStep
+}
+
+// referenceStepType represents the type of step in a reference.
+type referenceStepType int
+
+const (
+	referenceStepAttribute = 1
+	referenceStepIndex     = 2
+	referenceStepKey       = 3
+	referenceStepSplat     = 4
+)
+
+// referenceStep is a part of a reference to some value in a Terraform
+// configuration. A [Reference] might refer to a field of an attribute,
+// and that reference is made up of multiple referenceStep.
+type referenceStep struct {
+	stepType  referenceStepType
+	attribute string
+	index     int
+	key       string
 }
 
 // InternalTokens returns the tokens to represent this reference in Terraform
 // configurations
 func (r Reference) InternalTokens() hclwrite.Tokens {
-	var tr hcl.Traversal
+	var fullSteps []referenceStep
 	switch r.underlyingType {
 	case referenceResource:
-		tr = hcl.Traversal{
-			hcl.TraverseRoot{Name: r.res.Type()},
-			hcl.TraverseAttr{Name: r.res.LocalName()},
+		fullSteps = []referenceStep{
+			{
+				stepType:  referenceStepAttribute,
+				attribute: r.res.Type(),
+			},
+			{
+				stepType:  referenceStepAttribute,
+				attribute: r.res.LocalName(),
+			},
 		}
 	case referenceDataResource:
-		tr = hcl.Traversal{
-			hcl.TraverseRoot{Name: "data"},
-			hcl.TraverseAttr{Name: r.data.DataSource()},
-			hcl.TraverseAttr{Name: r.data.LocalName()},
+		fullSteps = []referenceStep{
+			{
+				stepType:  referenceStepAttribute,
+				attribute: "data",
+			},
+			{
+				stepType:  referenceStepAttribute,
+				attribute: r.data.DataSource(),
+			},
+			{
+				stepType:  referenceStepAttribute,
+				attribute: r.data.LocalName(),
+			},
 		}
 	default:
 		panic("unknown underlying type for reference")
 	}
-
-	tr = append(tr, r.tr...)
-
-	return hclwrite.TokensForTraversal(tr)
+	fullSteps = append(fullSteps, r.steps...)
+	tokens, err := tokensForSteps(fullSteps)
+	if err != nil {
+		panic(fmt.Sprintf("creating tokens for reference steps: %s", err))
+	}
+	return tokens
 }
 
 // Append appends the given string to the reference
 func (r Reference) Append(name string) Reference {
 	cp := r.copy()
-	cp.tr = append(cp.tr, hcl.TraverseAttr{Name: name})
+	cp.steps = append(
+		cp.steps, referenceStep{
+			stepType:  referenceStepAttribute,
+			attribute: name,
+		},
+	)
 	return cp
 }
 
 // index adds a reference to an index (of a list/set) to the reference
 func (r Reference) index(i int) Reference {
 	cp := r.copy()
-	cp.tr = append(cp.tr, hcl.TraverseIndex{Key: cty.NumberIntVal(int64(i))})
+	cp.steps = append(
+		cp.steps, referenceStep{
+			stepType: referenceStepIndex,
+			index:    i,
+		},
+	)
 	return cp
 }
 
 // key adds a reference to a key (of a map) to the reference
 func (r Reference) key(k string) Reference {
 	cp := r.copy()
-	cp.tr = append(cp.tr, hcl.TraverseIndex{Key: cty.StringVal(k)})
+	cp.steps = append(
+		cp.steps, referenceStep{
+			stepType: referenceStepKey,
+			key:      k,
+		},
+	)
 	return cp
 }
 
 // splat adds the Terraform splat operator to a reference
 func (r Reference) splat() Reference {
 	cp := r.copy()
-	cp.tr = append(cp.tr, hcl.TraverseSplat{})
+	cp.steps = append(
+		cp.steps, referenceStep{
+			stepType: referenceStepSplat,
+		},
+	)
 	return cp
 }
 
 // copy makes a copy of the reference so that any slices can be safely passed
 // around with modifying the original
 func (r Reference) copy() Reference {
-	tr := make(hcl.Traversal, len(r.tr))
-	copy(tr, r.tr)
+	steps := make([]referenceStep, len(r.steps))
+	copy(steps, r.steps)
 	return Reference{
 		underlyingType: r.underlyingType,
 		res:            r.res,
 		data:           r.data,
-		tr:             tr,
+		steps:          steps,
 	}
+}
+
+func tokensForSteps(steps []referenceStep) (hclwrite.Tokens, error) {
+	var tokens hclwrite.Tokens
+	for i, step := range steps {
+		switch step.stepType {
+		case referenceStepAttribute:
+			// If not the first step, add the "." separator
+			if i > 0 {
+				tokens = append(
+					tokens,
+					&hclwrite.Token{
+						Type:  hclsyntax.TokenDot,
+						Bytes: []byte{'.'},
+					},
+				)
+			}
+			tokens = append(
+				tokens,
+				hclwrite.TokensForIdentifier(step.attribute)...,
+			)
+		case referenceStepIndex:
+			tokens = append(
+				tokens,
+				&hclwrite.Token{
+					Type:  hclsyntax.TokenOBrack,
+					Bytes: []byte{'['},
+				},
+			)
+			tokens = append(
+				tokens,
+				hclwrite.TokensForValue(
+					cty.NumberIntVal(int64(step.index)),
+				)...,
+			)
+			tokens = append(
+				tokens,
+				&hclwrite.Token{
+					Type:  hclsyntax.TokenCBrack,
+					Bytes: []byte{']'},
+				},
+			)
+		case referenceStepKey:
+			tokens = append(
+				tokens,
+				&hclwrite.Token{
+					Type:  hclsyntax.TokenOBrack,
+					Bytes: []byte{'['},
+				},
+			)
+			tokens = append(
+				tokens,
+				hclwrite.TokensForValue(
+					cty.StringVal(step.key),
+				)...,
+			)
+			tokens = append(
+				tokens, &hclwrite.Token{
+					Type:  hclsyntax.TokenCBrack,
+					Bytes: []byte{']'},
+				},
+			)
+		case referenceStepSplat:
+			tokens = append(
+				tokens,
+				&hclwrite.Token{
+					Type:  hclsyntax.TokenOBrack,
+					Bytes: []byte{'['},
+				},
+				&hclwrite.Token{
+					Type:  hclsyntax.TokenStar,
+					Bytes: []byte{'*'},
+				},
+				&hclwrite.Token{
+					Type:  hclsyntax.TokenCBrack,
+					Bytes: []byte{']'},
+				},
+			)
+		default:
+			return nil, fmt.Errorf(
+				"unknown reference step type: %d",
+				step.stepType,
+			)
+		}
+	}
+	return tokens, nil
 }


### PR DESCRIPTION
Removing the dependence on hcl.Traversal removes the need to use a
forked and patched version of hcl to support the hcl.TraverseSplat

resolves #42
