### PR TITLE
Enable kube.App nested field

### DIFF
--- a/docs/platypus2/monitoring/vmk8s/app.go
+++ b/docs/platypus2/monitoring/vmk8s/app.go
@@ -34,7 +34,7 @@ type Vmk8S struct {
 	MonCoreDNS       *MonCoreDNS
 	MonETCD          *MonETCD
 
-	K8SRules // *K8SRules
+	K8SRules *K8SRules
 
 	DashboardK8SGlobalCM     *corev1.ConfigMap
 	DashboardK8SNamespacesCM *corev1.ConfigMap
@@ -69,7 +69,7 @@ func New() *Vmk8S {
 		MonCoreDNS:       NewMonCoreDNS(),
 		MonETCD:          NewMonETCD(),
 
-		K8SRules: *NewK8SRules(),
+		K8SRules: NewK8SRules(),
 
 		CadvisorNodeScrape: CadvisorNodeScrape,
 		ProbesNodeScrape:   ProbesNodeScrape,

--- a/docs/platypus2/monitoring/vmk8s/app.go
+++ b/docs/platypus2/monitoring/vmk8s/app.go
@@ -23,16 +23,16 @@ var _ kube.Exporter = (*Vmk8S)(nil)
 type Vmk8S struct {
 	kube.App
 
-	Operator         // *Operator
-	Grafana          // *Grafana
-	KubeStateMetrics // *KubeStateMetrics
-	NodeExporter     // *NodeExporter
-	VMAlertManager   // *VMAlertManager
+	Operator         *Operator
+	Grafana          *Grafana
+	KubeStateMetrics *KubeStateMetrics
+	NodeExporter     *NodeExporter
+	VMAlertManager   *VMAlertManager
 
-	MonKubeScheduler // *MonKubeScheduler
-	MonAPIServer     // *MonAPIServer
-	MonCoreDNS       // *MonCoreDNS
-	MonETCD          // *MonETCD
+	MonKubeScheduler *MonKubeScheduler
+	MonAPIServer     *MonAPIServer
+	MonCoreDNS       *MonCoreDNS
+	MonETCD          *MonETCD
 
 	K8SRules // *K8SRules
 
@@ -58,16 +58,16 @@ type Vmk8S struct {
 // New creates a new Vmk8S
 func New() *Vmk8S {
 	return &Vmk8S{
-		Operator:         *NewOperator(),
-		Grafana:          *NewGrafana(),
-		KubeStateMetrics: *NewKubeStateMetrics(),
-		NodeExporter:     *NewNodeExporter(),
-		VMAlertManager:   *NewVMAlertManager(),
+		Operator:         NewOperator(),
+		Grafana:          NewGrafana(),
+		KubeStateMetrics: NewKubeStateMetrics(),
+		NodeExporter:     NewNodeExporter(),
+		VMAlertManager:   NewVMAlertManager(),
 
-		MonAPIServer:     *NewMonAPIServer(),
-		MonKubeScheduler: *NewMonKubeScheduler(),
-		MonCoreDNS:       *NewMonCoreDNS(),
-		MonETCD:          *NewMonETCD(),
+		MonAPIServer:     NewMonAPIServer(),
+		MonKubeScheduler: NewMonKubeScheduler(),
+		MonCoreDNS:       NewMonCoreDNS(),
+		MonETCD:          NewMonETCD(),
 
 		K8SRules: *NewK8SRules(),
 

--- a/docs/platypus2/monitoring/vmk8s/cleanup_hook.go
+++ b/docs/platypus2/monitoring/vmk8s/cleanup_hook.go
@@ -6,6 +6,7 @@
 package vmk8s
 
 import (
+	"github.com/volvo-cars/lingon/pkg/kube"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -14,6 +15,8 @@ import (
 )
 
 type CleanUp struct {
+	kube.App
+
 	VMK8sCleanupHookCR   *rbacv1.ClusterRole
 	VMK8sCleanupHookCRB  *rbacv1.ClusterRoleBinding
 	VMK8sCleanupHookJOBS *batchv1.Job
@@ -142,7 +145,7 @@ var VMK8sCleanupHookJOBS = &batchv1.Job{
 								`kubectl delete vmclusters --all --ignore-not-found=true;`,
 						},
 						Image:           "gcr.io/google_containers/hyperkube:v1.18.0",
-						ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
+						ImagePullPolicy: corev1.PullIfNotPresent,
 						Name:            "kubectl",
 						Resources: corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{

--- a/docs/platypus2/monitoring/vmk8s/grafana.go
+++ b/docs/platypus2/monitoring/vmk8s/grafana.go
@@ -5,6 +5,7 @@ package vmk8s
 
 import (
 	"github.com/VictoriaMetrics/operator/api/victoriametrics/v1beta1"
+	"github.com/volvo-cars/lingon/pkg/kube"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -13,6 +14,8 @@ import (
 )
 
 type Grafana struct {
+	kube.App
+
 	CM                 *corev1.ConfigMap
 	CR                 *rbacv1.ClusterRole
 	CRB                *rbacv1.ClusterRoleBinding
@@ -120,7 +123,7 @@ var GrafanaDeploy = &appsv1.Deployment{
 							},
 						},
 						Image:           "quay.io/kiwigrid/k8s-sidecar:1.19.2",
-						ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
+						ImagePullPolicy: corev1.PullIfNotPresent,
 						Name:            "grafana-sc-dashboard",
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -167,7 +170,7 @@ var GrafanaDeploy = &appsv1.Deployment{
 							},
 						},
 						Image:           "quay.io/kiwigrid/k8s-sidecar:1.19.2",
-						ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
+						ImagePullPolicy: corev1.PullIfNotPresent,
 						Name:            "grafana-sc-datasources",
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -208,7 +211,7 @@ var GrafanaDeploy = &appsv1.Deployment{
 							},
 						},
 						Image:           "grafana/grafana:9.3.0",
-						ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
+						ImagePullPolicy: corev1.PullIfNotPresent,
 						LivenessProbe: &corev1.Probe{
 							FailureThreshold:    int32(10),
 							InitialDelaySeconds: int32(60),
@@ -272,7 +275,7 @@ var GrafanaDeploy = &appsv1.Deployment{
 						},
 						Command:         []string{"/bin/sh"},
 						Image:           "curlimages/curl:7.85.0",
-						ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
+						ImagePullPolicy: corev1.PullIfNotPresent,
 						Name:            "download-dashboards",
 						VolumeMounts: []corev1.VolumeMount{
 							{
@@ -778,7 +781,7 @@ var GrafanaTestPO = &corev1.Pod{
 					"/tests/run.sh",
 				},
 				Image:           "bats/bats:v1.4.1",
-				ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
+				ImagePullPolicy: corev1.PullIfNotPresent,
 				Name:            "vmk8s-test",
 				VolumeMounts: []corev1.VolumeMount{
 					{

--- a/docs/platypus2/monitoring/vmk8s/kube_state_metrics.go
+++ b/docs/platypus2/monitoring/vmk8s/kube_state_metrics.go
@@ -5,6 +5,7 @@ package vmk8s
 
 import (
 	"github.com/VictoriaMetrics/operator/api/victoriametrics/v1beta1"
+	"github.com/volvo-cars/lingon/pkg/kube"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -13,6 +14,8 @@ import (
 )
 
 type KubeStateMetrics struct {
+	kube.App
+
 	CR     *rbacv1.ClusterRole
 	CRB    *rbacv1.ClusterRoleBinding
 	Deploy *appsv1.Deployment
@@ -76,7 +79,7 @@ var KubeStateMetricsDeploy = &appsv1.Deployment{
 							"--resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments",
 						},
 						Image:           "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.7.0",
-						ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
+						ImagePullPolicy: corev1.PullIfNotPresent,
 						LivenessProbe: &corev1.Probe{
 							InitialDelaySeconds: int32(5),
 							ProbeHandler: corev1.ProbeHandler{

--- a/docs/platypus2/monitoring/vmk8s/mon_api_server.go
+++ b/docs/platypus2/monitoring/vmk8s/mon_api_server.go
@@ -5,10 +5,13 @@ package vmk8s
 
 import (
 	"github.com/VictoriaMetrics/operator/api/victoriametrics/v1beta1"
+	"github.com/volvo-cars/lingon/pkg/kube"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type MonAPIServer struct {
+	kube.App
+
 	APIServerAvailabilityRules *v1beta1.VMRule
 	APIServerBurnRateRules     *v1beta1.VMRule
 	APIServerHistogramRules    *v1beta1.VMRule

--- a/docs/platypus2/monitoring/vmk8s/mon_coredns.go
+++ b/docs/platypus2/monitoring/vmk8s/mon_coredns.go
@@ -5,12 +5,15 @@ package vmk8s
 
 import (
 	"github.com/VictoriaMetrics/operator/api/victoriametrics/v1beta1"
+	"github.com/volvo-cars/lingon/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type MonCoreDNS struct {
+	kube.App
+
 	SVC         *corev1.Service
 	Scrape      *v1beta1.VMServiceScrape
 	DashboardCM *corev1.ConfigMap

--- a/docs/platypus2/monitoring/vmk8s/mon_etcd.go
+++ b/docs/platypus2/monitoring/vmk8s/mon_etcd.go
@@ -5,12 +5,15 @@ package vmk8s
 
 import (
 	"github.com/VictoriaMetrics/operator/api/victoriametrics/v1beta1"
+	"github.com/volvo-cars/lingon/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type MonETCD struct {
+	kube.App
+
 	ETCDRules  *v1beta1.VMRule
 	ETCDSvc    *corev1.Service
 	ETCDScrape *v1beta1.VMServiceScrape

--- a/docs/platypus2/monitoring/vmk8s/mon_kube_controller.go
+++ b/docs/platypus2/monitoring/vmk8s/mon_kube_controller.go
@@ -5,12 +5,15 @@ package vmk8s
 
 import (
 	"github.com/VictoriaMetrics/operator/api/victoriametrics/v1beta1"
+	"github.com/volvo-cars/lingon/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type MonKubeController struct {
+	kube.App
+
 	SVC        *corev1.Service
 	Scrape     *v1beta1.VMServiceScrape
 	AlertRules *v1beta1.VMRule

--- a/docs/platypus2/monitoring/vmk8s/mon_kube_proxy.go
+++ b/docs/platypus2/monitoring/vmk8s/mon_kube_proxy.go
@@ -5,12 +5,15 @@ package vmk8s
 
 import (
 	"github.com/VictoriaMetrics/operator/api/victoriametrics/v1beta1"
+	"github.com/volvo-cars/lingon/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type MonKubeProxy struct {
+	kube.App
+
 	KubeProxySVC    *corev1.Service
 	KubeProxyScrape *v1beta1.VMServiceScrape
 }

--- a/docs/platypus2/monitoring/vmk8s/mon_kube_scheduler.go
+++ b/docs/platypus2/monitoring/vmk8s/mon_kube_scheduler.go
@@ -5,12 +5,15 @@ package vmk8s
 
 import (
 	"github.com/VictoriaMetrics/operator/api/victoriametrics/v1beta1"
+	"github.com/volvo-cars/lingon/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 type MonKubeScheduler struct {
+	kube.App
+
 	KubeSchedulerRules      *v1beta1.VMRule
 	KubeSchedulerAlertRules *v1beta1.VMRule
 	KubeSchedulerSVC        *corev1.Service

--- a/docs/platypus2/monitoring/vmk8s/node_exporter.go
+++ b/docs/platypus2/monitoring/vmk8s/node_exporter.go
@@ -7,6 +7,7 @@ package vmk8s
 
 import (
 	"github.com/VictoriaMetrics/operator/api/victoriametrics/v1beta1"
+	"github.com/volvo-cars/lingon/pkg/kube"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,6 +15,8 @@ import (
 )
 
 type NodeExporter struct {
+	kube.App
+
 	DS         *appsv1.DaemonSet
 	SA         *corev1.ServiceAccount
 	SVC        *corev1.Service
@@ -87,7 +90,7 @@ var NodeExporterDS = &appsv1.DaemonSet{
 							},
 						},
 						Image:           "quay.io/prometheus/node-exporter:v1.4.0",
-						ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
+						ImagePullPolicy: corev1.PullIfNotPresent,
 						LivenessProbe: &corev1.Probe{
 							FailureThreshold: int32(3),
 							PeriodSeconds:    int32(10),

--- a/docs/platypus2/monitoring/vmk8s/operator.go
+++ b/docs/platypus2/monitoring/vmk8s/operator.go
@@ -5,6 +5,7 @@ package vmk8s
 
 import (
 	"github.com/VictoriaMetrics/operator/api/victoriametrics/v1beta1"
+	"github.com/volvo-cars/lingon/pkg/kube"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -13,6 +14,8 @@ import (
 )
 
 type Operator struct {
+	kube.App
+
 	CR          *rbacv1.ClusterRole
 	CRB         *rbacv1.ClusterRoleBinding
 	Deploy      *appsv1.Deployment
@@ -112,7 +115,7 @@ var OperatorDeploy = &appsv1.Deployment{
 							},
 						},
 						Image:           "victoriametrics/operator:v0.34.1",
-						ImagePullPolicy: corev1.PullPolicy("IfNotPresent"),
+						ImagePullPolicy: corev1.PullIfNotPresent,
 						Name:            "victoria-metrics-operator",
 						Ports: []corev1.ContainerPort{
 							{

--- a/docs/platypus2/monitoring/vmk8s/rules_k8s.go
+++ b/docs/platypus2/monitoring/vmk8s/rules_k8s.go
@@ -7,10 +7,13 @@ package vmk8s
 
 import (
 	"github.com/VictoriaMetrics/operator/api/victoriametrics/v1beta1"
+	"github.com/volvo-cars/lingon/pkg/kube"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type K8SRules struct {
+	kube.App
+
 	K8SRecordingRules             *v1beta1.VMRule
 	K8SGeneralAlertRules          *v1beta1.VMRule
 	PromGeneralRules              *v1beta1.VMRule

--- a/docs/platypus2/monitoring/vmk8s/vmalertmanager.go
+++ b/docs/platypus2/monitoring/vmk8s/vmalertmanager.go
@@ -7,11 +7,14 @@ package vmk8s
 
 import (
 	"github.com/VictoriaMetrics/operator/api/victoriametrics/v1beta1"
+	"github.com/volvo-cars/lingon/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type VMAlertManager struct {
+	kube.App
+
 	VMK8sVmalertmanager         *v1beta1.VMAlertmanager
 	VMK8sVmalert                *v1beta1.VMAlert
 	VMK8sAlertmanagerMonzoTplCM *corev1.ConfigMap

--- a/pkg/kube/encode.go
+++ b/pkg/kube/encode.go
@@ -44,6 +44,14 @@ func (g *goky) encodeStruct(
 
 		fieldVal := rv.FieldByName(sf.Name)
 		switch t := fieldVal.Interface().(type) {
+		case Exporter:
+			if fv.Kind() == reflect.Ptr {
+				fv = fv.Elem()
+			}
+			if err := g.encodeStruct(fv, sf.Name); err != nil {
+				return err
+			}
+			continue
 		case runtime.Object:
 			v := reflect.ValueOf(t)
 			// TODO: should we continue instead ? Should it be an option ?

--- a/pkg/kube/export_embed_example_test.go
+++ b/pkg/kube/export_embed_example_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Volvo Car Corporation
+// SPDX-License-Identifier: Apache-2.0
+
 package kube_test
 
 import (

--- a/pkg/kube/export_embed_example_test.go
+++ b/pkg/kube/export_embed_example_test.go
@@ -1,0 +1,73 @@
+package kube_test
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/volvo-cars/lingon/pkg/kube"
+	"github.com/volvo-cars/lingon/pkg/kubeutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type SubApp struct {
+	kube.App
+
+	CM *corev1.ConfigMap
+}
+
+func NewSubApp() *SubApp {
+	return &SubApp{
+		CM: &corev1.ConfigMap{
+			TypeMeta: kubeutil.TypeConfigMapV1,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "config-map-name",
+				Namespace: "my-ns",
+			},
+			Data: map[string]string{"key": "value"},
+		},
+	}
+}
+
+type MainApp struct {
+	kube.App
+
+	SubApp *SubApp
+	NS     *corev1.Namespace
+}
+
+func NewApp() *MainApp {
+	return &MainApp{
+		SubApp: NewSubApp(),
+		NS: &corev1.Namespace{
+			TypeMeta:   kubeutil.TypeNamespaceV1,
+			ObjectMeta: metav1.ObjectMeta{Name: "my-ns"},
+		},
+	}
+}
+
+func ExampleExport_embedded() {
+	app := NewApp()
+
+	var buf bytes.Buffer
+	_ = kube.Export(app, kube.WithExportWriter(&buf))
+
+	fmt.Printf("%s\n", buf.String())
+
+	// Output:
+	//
+	// -- out/0_ns.yaml --
+	// apiVersion: v1
+	// kind: Namespace
+	// metadata:
+	//   name: my-ns
+	// spec: {}
+	// -- out/2_sub_appcm.yaml --
+	// apiVersion: v1
+	// data:
+	//   key: value
+	// kind: ConfigMap
+	// metadata:
+	//   name: config-map-name
+	//   namespace: my-ns
+}

--- a/pkg/kube/export_example_test.go
+++ b/pkg/kube/export_example_test.go
@@ -7,11 +7,9 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/rogpeppe/go-internal/txtar"
 	"github.com/volvo-cars/lingon/pkg/kube"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/yaml"
 )
 
 // validate the struct implements the interface
@@ -48,30 +46,16 @@ func ExampleExport() {
 	var buf bytes.Buffer
 	_ = kube.Export(tk, kube.WithExportWriter(&buf))
 
-	ar := txtar.Parse(buf.Bytes())
-
-	if len(ar.Files) > 0 {
-		ns := &corev1.Namespace{}
-		_ = yaml.Unmarshal(ar.Files[0].Data, ns)
-		// print line by line to avoid trailing whitespace
-		fmt.Println("apiVersion:", ns.APIVersion)
-		fmt.Println("kind:", ns.Kind)
-		fmt.Println("metadata:")
-		fmt.Println("  labels:")
-		fmt.Println(
-			"    app.kubernetes.io/name:",
-			ns.Labels["app.kubernetes.io/name"],
-		)
-		fmt.Println("name:", ns.Name)
-	}
+	fmt.Printf("%s\n", buf.String())
 
 	// Output:
 	//
+	// -- out/0_pipelines_ns.yaml --
 	// apiVersion: v1
 	// kind: Namespace
 	// metadata:
 	//   labels:
 	//     app.kubernetes.io/name: tekton-pipelines
-	// name: tekton-pipelines
-	//
+	//   name: tekton-pipelines
+	// spec: {}
 }


### PR DESCRIPTION
It is now possible to nest a `kube.App` struct inside another `kube.App` struct as a field.

Note that struct embedding still works, it is just more flexible now. 

Example: `pkg/kube/export_embed_example_test.go`